### PR TITLE
June #1 Minor bug fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     output_path="optimeering-python-sdk",
     provides=python_artifact(
         name="optimeering",
-        version="0.0.2",
+        version="0.0.3",
         description="Optimeering Python Client",
         long_description_content_type="text/markdown",
         author="Optimeering",

--- a/generate/python_templates/api.mustache
+++ b/generate/python_templates/api.mustache
@@ -101,7 +101,11 @@ class {{classname}}:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item=next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)

--- a/generate/python_templates/partial_api_args_pagination_removed.mustache
+++ b/generate/python_templates/partial_api_args_pagination_removed.mustache
@@ -17,9 +17,9 @@
         {{#vendorExtensions.x-optimeering-comma-separated.data-type}}
         {{! OPTIMEERING PYTHON TYPE OVERWRITE}}
         {{paramName}}: Annotated[
-            {{^required}}Optional[{{/required}}{{{vendorExtensions.x-optimeering-comma-separated.data-type}}}{{^required}}]{{/required}}{{^required}},
+            {{^required}}Optional[{{/required}}{{{vendorExtensions.x-optimeering-comma-separated.data-type}}}{{^required}}]{{/required}},
             Field(description="{{#description}}{{{.}}}{{/description}}")
-        ] = None{{/required}},        {{/vendorExtensions.x-optimeering-comma-separated.data-type}}
+        ] {{^required}}= None{{/required}},        {{/vendorExtensions.x-optimeering-comma-separated.data-type}}
         {{/vendorExtensions.x-optimeering-pagination-parameter.value}}
         {{/allParams}}
         _request_timeout: Union[

--- a/optimeering/api/access_api.py
+++ b/optimeering/api/access_api.py
@@ -261,7 +261,11 @@ class AccessApi:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item = next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)

--- a/optimeering/api/predictions_api.py
+++ b/optimeering/api/predictions_api.py
@@ -232,7 +232,11 @@ class PredictionsApi:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item = next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)
@@ -585,7 +589,11 @@ class PredictionsApi:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item = next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)
@@ -743,7 +751,11 @@ class PredictionsApi:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item = next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)
@@ -911,7 +923,11 @@ class PredictionsApi:
             next_page = next_pagination.next_page
 
             if attribute_to_extend_selected:
-                if next_pagination.items[0].series_id == paginated_response.items[-1].series_id:
+                try:
+                    first_item = next_pagination.items[0]
+                except IndexError:
+                    break
+                if first_item.series_id == paginated_response.items[-1].series_id:
                     # if series id is same, extract the first item and extend to last item
                     continued_data: List = getattr(next_pagination.items.pop(0), attribute_to_extend_selected)
                     previous_data: List = getattr(paginated_response.items[-1], attribute_to_extend_selected)


### PR DESCRIPTION
Handle edge case where number of items to be returned is a multiple of limit causing last response from API to have no items; but collapsing response together directly accesses the 1st item causing index error.

Descriptions were not being added if the parameter was not required.